### PR TITLE
Use pkg-config in build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ use-bindgen = ["bindgen"]
 
 [build-dependencies]
 bindgen = { version = "0.63.0", optional = true }
+pkg-config = "0.3.15"
 
 
 [package.metadata.release]

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,18 @@
 use std::env;
 #[cfg(feature = "use-bindgen")]
 use std::path::PathBuf;
+use std::process;
 
 fn main() {
     // Tell cargo to tell rustc to link the system heif
     // shared library.
-    println!("cargo:rustc-link-lib=heif");
+    if let Err(err) = pkg_config::Config::new()
+        .atleast_version("1.14")
+        .probe("libheif")
+    {
+        println!("cargo:warning={}", err);
+        process::exit(1);
+    }
 
     #[cfg(feature = "use-bindgen")]
     {


### PR DESCRIPTION
The previous approach relied on the library being in the linker's default paths.