### PR TITLE
build: run vcpkg only for Windows-MSVC

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,14 +12,14 @@ fn main() {
 
     // Tell cargo to tell rustc to link the heif library.
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(all(target_os = "windows", target_env = "msvc")))]
     #[allow(unused_variables)]
     let include_paths = find_libheif();
 
-    #[cfg(target_os = "windows")]
+    #[cfg(all(target_os = "windows", target_env = "msvc"))]
     #[allow(unused_variables)]
     let include_paths: Vec<String> = Vec::new();
-    #[cfg(target_os = "windows")]
+    #[cfg(all(target_os = "windows", target_env = "msvc"))]
     install_libheif_by_vcpkg();
 
     #[cfg(feature = "use-bindgen")]
@@ -133,7 +133,7 @@ fn compile_libheif() -> String {
         .to_string()
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(all(target_os = "windows", target_env = "msvc")))]
 fn find_libheif() -> Vec<String> {
     #[allow(unused_mut)]
     let mut config = system_deps::Config::new();
@@ -175,7 +175,7 @@ fn find_libheif() -> Vec<String> {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", target_env = "msvc"))]
 fn install_libheif_by_vcpkg() {
     let vcpkg_lib = vcpkg::Config::new()
         .emit_includes(true)


### PR DESCRIPTION
windows-gnu and windows-gnullvm toolchains are not supported by vcpkg, so downstream packages fail to build `cargo:warning=the vcpkg-rs Vcpkg build helper can only find libraries built for the MSVC ABI.`